### PR TITLE
fix: rename ARC to ACR

### DIFF
--- a/environments/prod/main.tf
+++ b/environments/prod/main.tf
@@ -103,8 +103,8 @@ module "ai" {
 }
 
 # Azure Container Registry Module
-module "arc" {
-  source                             = "../../modules/arc"
+module "acr" {
+  source                             = "../../modules/acr"
   subscription_id                    = var.subscription_id
   main_resource_group_name           = var.main_resource_group_name
   location                           = var.location
@@ -115,7 +115,7 @@ module "arc" {
   depends_on = [azurerm_resource_group.mentorklub]
 
   # Only create resources if the module is enabled
-  count = var.modules_enabled["arc"] ? 1 : 0
+  count = var.modules_enabled["acr"] ? 1 : 0
 }
 
 # Database Module

--- a/environments/prod/outputs.tf
+++ b/environments/prod/outputs.tf
@@ -23,7 +23,11 @@ output "storage_account_name" {
 }
 
 output "acr_login_server" {
-  value = var.modules_enabled.arc ? module.arc[0].acr_login_server : null
+  value = var.modules_enabled.acr ? module.acr[0].acr_login_server : null
+}
+
+output "acr_todo_message" {
+  value = var.modules_enabled.acr ? module.acr[0].todo_message : null
 }
 
 output "sql_server_fqdn" {
@@ -34,3 +38,5 @@ output "sql_database_name" {
   value = var.modules_enabled.sql ? module.sql[0].database_name : null
 
 }
+
+

--- a/modules/acr/main.tf
+++ b/modules/acr/main.tf
@@ -5,7 +5,7 @@ resource "azurerm_resource_group" "acr" {
 }
 
 # Add resource lock on Docker resource group
-resource "azurerm_management_lock" "mentorklub_arc_rg_lock" {
+resource "azurerm_management_lock" "mentorklub_acr_rg_lock" {
   name       = "DeleteLockMentorKlubDockerRG"
   scope      = azurerm_resource_group.acr.id
   lock_level = "CanNotDelete"

--- a/modules/acr/outputs.tf
+++ b/modules/acr/outputs.tf
@@ -1,0 +1,10 @@
+
+
+output "acr_login_server" {
+  value = azurerm_container_registry.acr.login_server
+
+}
+
+output "todo_message" {
+  value = "TODO: You must create Azure DevOps Service Conection manually for the Azure Container Registry (ACR) to enable CI/CD pipeline. Or add it cloudsteak-MentorKlub-f96295a4-0752-4228-ad35-419f404433a0 service principal with ACRPush role."
+}

--- a/modules/acr/outputs.tf
+++ b/modules/acr/outputs.tf
@@ -6,5 +6,5 @@ output "acr_login_server" {
 }
 
 output "todo_message" {
-  value = "TODO: You must create Azure DevOps Service Conection manually for the Azure Container Registry (ACR) to enable CI/CD pipeline. Or add it cloudsteak-MentorKlub-f96295a4-0752-4228-ad35-419f404433a0 service principal with ACRPush role."
+  value = "TODO: You must create Azure DevOps Service Conection manually for the Azure Container Registry (ACR) to enable CI/CD pipeline. Or add the right service principal to it with ACRPush role."
 }

--- a/modules/acr/variables.tf
+++ b/modules/acr/variables.tf
@@ -37,7 +37,7 @@ variable "entra_id_group_name" {
 }
 
 ##############
-# ARC Inputs #
+# ACR Inputs #
 ##############
 
 variable "resource_group_name_prefix" {

--- a/modules/arc/outputs.tf
+++ b/modules/arc/outputs.tf
@@ -1,6 +1,0 @@
-
-
-output "acr_login_server" {
-  value = azurerm_container_registry.acr.login_server
-
-}


### PR DESCRIPTION
This pull request includes several changes to rename the `arc` module to `acr` across multiple files and update related references accordingly. The most important changes include renaming the module in `main.tf`, updating output references, and modifying resource names.

Module renaming:

* [`environments/prod/main.tf`](diffhunk://#diff-78317895bd487f13e0e5c77ebca0b41d4e63939b971c09ccd25f421b73329c23L106-R107): Renamed the `arc` module to `acr` and updated the source path and count variable. [[1]](diffhunk://#diff-78317895bd487f13e0e5c77ebca0b41d4e63939b971c09ccd25f421b73329c23L106-R107) [[2]](diffhunk://#diff-78317895bd487f13e0e5c77ebca0b41d4e63939b971c09ccd25f421b73329c23L118-R118)

Output references:

* [`environments/prod/outputs.tf`](diffhunk://#diff-edbc1ac02c056fa33f2223276d5c713de4084a4d94a67a41be0a9288a64b904eL26-R30): Updated output references from `arc` to `acr` and added a new output `acr_todo_message`. [[1]](diffhunk://#diff-edbc1ac02c056fa33f2223276d5c713de4084a4d94a67a41be0a9288a64b904eL26-R30) [[2]](diffhunk://#diff-edbc1ac02c056fa33f2223276d5c713de4084a4d94a67a41be0a9288a64b904eR41-R42)

Resource names:

* [`modules/acr/main.tf`](diffhunk://#diff-853dae0640bc43d60d78982185bffb04bf52b48521688cbcb17f5d4fda7541d8L8-R8): Renamed the resource lock from `mentorklub_arc_rg_lock` to `mentorklub_acr_rg_lock`.

New outputs:

* [`modules/acr/outputs.tf`](diffhunk://#diff-7a055fe40315c04691cb786ca0aff32c8b8515272f48f8aef5088836fa9f0074R1-R10): Added new outputs `acr_login_server` and `todo_message`.

Variable renaming:

* [`modules/acr/variables.tf`](diffhunk://#diff-114454f7302bbd99a56ee25df051866dede3ae89ef7ac06085d0b225ed8f84f6L40-R40): Updated comments to reflect the renaming from `ARC` to `ACR`.

These changes ensure consistency in naming conventions and improve clarity by accurately reflecting the purpose of the module.